### PR TITLE
fix gui code bug

### DIFF
--- a/snntoolbox/bin/gui/gui.py
+++ b/snntoolbox/bin/gui/gui.py
@@ -1509,7 +1509,7 @@ def main():
 
     from snntoolbox.bin.utils import load_config
     config = load_config(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                      '..', '..', 'snntoolbox',
+                                                      '..', '..',
                                                       'config_defaults')))
 
     root = tk.Tk()


### PR DESCRIPTION
the code in 'snntoolbox/bin/gui/gui.py' line 1512 has a small bug,
os.path.join(os.path.dirname(__file__), '..', '..','snntoolbox' 'config_defaults'), here the 3rd string 'snntoolbox' should not be included because the path is used relatively. After removing it, I can run the gui without error.